### PR TITLE
Sécurisation des informations de connexion

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -2,6 +2,10 @@
 <configuration>
     <configSections>
     </configSections>
+	<connectionStrings>
+		<add name="MediaTekDocuments.Properties.Settings.apiAuthenticationString"
+            connectionString="admin:adminpwd" />
+	</connectionStrings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -18,6 +18,9 @@ namespace MediaTekDocuments.dal
         /// adresse de l'API
         /// </summary>
         private static readonly string uriApi = "http://localhost/rest_mediatekdocuments/";
+
+        private static readonly string connectionName = "MediaTekDocuments.Properties.Settings.apiAuthenticationString";
+
         /// <summary>
         /// instance unique de la classe
         /// </summary>
@@ -49,7 +52,7 @@ namespace MediaTekDocuments.dal
             String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
+                authenticationString = GetConnectionStringByName(connectionName);
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)
@@ -70,6 +73,15 @@ namespace MediaTekDocuments.dal
                 instance = new Access();
             }
             return instance;
+        }
+
+        static string GetConnectionStringByName(string name)
+        {
+            string returnValue = null;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[name];
+            if (settings != null)
+                returnValue = settings.ConnectionString;
+            return returnValue;
         }
 
         /// <summary>


### PR DESCRIPTION
Le couple login:pwd était écrit en dur dans le fichier Access.cs. Il a été déplacé dans le fichier App.Config. 